### PR TITLE
Suppress timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.3 (2021-08-10)
+
+* Allow suppressing timeout by aiopg_listen.NO_TIMEOUT [#9](https://github.com/Pliner/aiopg-listen/pull/9)
+
 ## v0.0.2 (2021-07-25)
 
 * Add `aiopg_listen.connect_func` to simplify initialization [#5](https://github.com/Pliner/aiopg-listen/pull/5)

--- a/aiopg_listen/__init__.py
+++ b/aiopg_listen/__init__.py
@@ -3,6 +3,7 @@ import re
 import sys
 
 from .listener import (  # noqa
+    NO_TIMEOUT,
     ConnectFunc,
     ListenPolicy,
     Notification,

--- a/aiopg_listen/listener.py
+++ b/aiopg_listen/listener.py
@@ -39,6 +39,7 @@ NotificationOrTimeout = Union[Notification, Timeout]
 NotificationHandler = Callable[[NotificationOrTimeout], Awaitable]
 
 NO_TIMEOUT: float = -1
+NO_TIMEOUT_CTX = contextlib.nullcontext()
 
 
 def connect_func(*args: Any, **kwargs: Any) -> ConnectFunc:
@@ -102,7 +103,7 @@ class NotificationListener:
             if notifications.empty():
                 try:
                     timeout_ctx = (
-                        contextlib.nullcontext
+                        NO_TIMEOUT_CTX
                         if notification_timeout == NO_TIMEOUT
                         else async_timeout.timeout(timeout=notification_timeout)
                     )


### PR DESCRIPTION
Allow to not receive Timeout notification.

```
listener.run({"simple": handler.handle}, notification_timeout=aiopg_listen.NO_TIMEOUT)
```